### PR TITLE
Fixed deprecation of Fixnum and Bignum

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+2017-10-26 -- 1.0.3
+
+- Fixed Fixnum, Bignum deprecation for ruby 2.4 (https://bugs.ruby-lang.org/issues/12739)
+
+---
+
 2015-07-14 -- 1.0.0
 
 - Forked project from SourceForce to GitHub

--- a/rb-scpt.gemspec
+++ b/rb-scpt.gemspec
@@ -2,7 +2,7 @@ require "rubygems"
 
 Gem::Specification.new do |s|
   s.name = "rb-scpt"
-  s.version = "1.0.2"
+  s.version = "1.0.3"
   s.homepage = "https://github.com/BrendanThompson/rb-scpt"
   s.summary="This is a fork of the original rb-appscript. Ruby AppleScript (rb-scpt) is a high-level, user-friendly Apple event bridge that allows you to control scriptable Mac OS X applications using ordinary Ruby scripts."
   s.files = Dir["**/*"].delete_if { |name| ["MakeFile", "ae.bundle", "mkmf.log", "rbae.o", "SendThreadSafe.o", "src/osx_ruby.h", "src/osx_intern.h"].include?(name) }

--- a/src/lib/_aem/codecs.rb
+++ b/src/lib/_aem/codecs.rb
@@ -233,7 +233,7 @@ class Codecs
     case val
     when AEMReference::Query then val.AEM_pack_self(self)
 
-    when Fixnum, Bignum then
+    when Integer then
       if SInt32Bounds === val
         AE::AEDesc.new(KAE::TypeSInt32, [val].pack('l'))
       elsif SInt64Bounds === val


### PR DESCRIPTION
Hi, because of deprecation warnings I changed the code to work well with ruby 2.4+.
I tested it manually with ruby 2.4.2 and 2.1.0. The tests in the test directory fail with unrelated errors.