### PR TITLE
Added first pass at getting CI running on GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+---
+name: CI
+
+# https://github.com/actions/checkout
+# https://github.com/ruby/setup-ruby
+# https://github.com/actions/virtual-environments#available-environments
+# https://github.com/ruby/setup-ruby/blob/master/README.md#supported-platforms
+
+'on': [push, pull_request, workflow_dispatch]
+
+jobs:
+  test:
+    name: >-
+      test ${{ matrix.os }} ${{ matrix.ruby }}
+
+    runs-on: ${{ matrix.os }}
+    if: |
+      !(   contains(github.event.pull_request.title,  '[ci skip]')
+        || contains(github.event.pull_request.title,  '[skip ci]'))
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+        ruby:
+          - ruby
+          - head
+
+    steps:
+      - name: repo checkout
+        uses: actions/checkout@v4
+
+      - name: load ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler: none
+
+      - name: install dependencies
+        run: gem install rake-compiler -N
+
+      - name: rake test
+        run: |
+          rake test
+        timeout-minutes: 3


### PR DESCRIPTION
Fails! But I think that might be a permissions issue trying to send applescript commands to TextEdit? It might be totally valid for the CI setup. We could either do something more generic (script extension?) or skip on CI? 

The fact that it builds is the main thing I wanted to see. This is a definite improvement.